### PR TITLE
pin sniffio<1.3.1 in wheelhouse.txt

### DIFF
--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,0 +1,1 @@
+sniffio<1.3.1  # 1.3.1 requires setuptools>=64


### PR DESCRIPTION
Due to https://github.com/python-trio/sniffio/pull/49 sniffio requires a newer version of setuptools to install.  

Since we can't move setuptools or the method sniffio installed, we've go to pin. 
Though this would be MUCH better to change in layer:basic -- that repo is read-only now. 

This is the only hope