### PR TITLE
Adjust exception catching for changed error strings in aws-cli

### DIFF
--- a/src/lib/charms/layer/aws.py
+++ b/src/lib/charms/layer/aws.py
@@ -23,7 +23,6 @@ from charms.reactive import endpoint_from_name
 
 from charms.layer import status
 
-
 ENTITY_PREFIX = "charm.aws"
 MODEL_UUID = os.environ["JUJU_MODEL_UUID"]
 MACHINE_ID = os.environ["JUJU_MACHINE_ID"]
@@ -595,7 +594,7 @@ class AWSError(Exception):
         meta-subclass for certain `error_type`s.
         """
         error_type = None
-        match = re.match(r"An error occurred \(([^)]+)\)", message)
+        match = re.search(r"An error occurred \(([^)]+)\)", message)
         if match:
             error_type = match.group(1)
         for error_cls in (DoesNotExistAWSError, AlreadyExistsAWSError):

--- a/src/wheelhouse.txt
+++ b/src/wheelhouse.txt
@@ -1,1 +1,1 @@
-setuptools==70.3.0
+setuptools==77.0.3

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,4 @@
 import charms.unit_test
 
-
 charms.unit_test.patch_reactive()
 charms.unit_test.patch_module("yaml")

--- a/tests/unit/test_aws_integrator.py
+++ b/tests/unit/test_aws_integrator.py
@@ -11,7 +11,6 @@ from charms import layer
 from charms.layer import aws as layer_aws
 from reactive import aws as reactive_aws
 
-
 _aws = patch_fixture("charms.layer.aws._aws")
 mysql_api = patch_fixture("charms.layer.aws.MySQLRDSManager")
 

--- a/tests/unit/test_layer_aws.py
+++ b/tests/unit/test_layer_aws.py
@@ -71,3 +71,76 @@ def test_aws_iam_tag_role(aws_mock):
         "--tags",
         f"Key=juju-model-uuid,Value={TEST_MODEL_UUID}",
     )
+
+
+@pytest.mark.parametrize(
+    "message, expected_cls, expected_error_type",
+    [
+        # No recognisable error code → base AWSError with None type
+        (
+            "Something went wrong",
+            aws.AWSError,
+            None,
+        ),
+        # Standard AWS CLI prefix: "An error occurred (Code) when calling …"
+        (
+            "An error occurred (NoSuchEntity) when calling the GetRole operation: "
+            "Role charm.aws.test-role not found.",
+            aws.DoesNotExistAWSError,
+            "NoSuchEntity",
+        ),
+        (
+            "An error occurred (InvalidParameterValue) when calling the CreateRole "
+            "operation: Invalid parameter.",
+            aws.DoesNotExistAWSError,
+            "InvalidParameterValue",
+        ),
+        (
+            "An error occurred (DBInstanceNotFound) when describing instances "
+            "operation: DB instance not found.",
+            aws.DoesNotExistAWSError,
+            "DBInstanceNotFound",
+        ),
+        (
+            "An error occurred (EntityAlreadyExists) when calling the CreateRole "
+            "operation: Role with name charm.aws.test-role already exists.",
+            aws.AlreadyExistsAWSError,
+            "EntityAlreadyExists",
+        ),
+        (
+            "An error occurred (LimitExceeded) when calling the CreateRole operation: "
+            "Limit exceeded.",
+            aws.AlreadyExistsAWSError,
+            "LimitExceeded",
+        ),
+        (
+            "An error occurred (IncorrectState) when calling the DeleteDBInstance "
+            "operation: Incorrect state.",
+            aws.AlreadyExistsAWSError,
+            "IncorrectState",
+        ),
+        # Unknown error code → base AWSError with the code preserved
+        (
+            "An error occurred (UnknownCode) when calling the SomeOperation operation.",
+            aws.AWSError,
+            "UnknownCode",
+        ),
+        # Error code NOT at the start of the string — re.search (not re.match) is needed
+        (
+            "aws: [ERROR]: An error occurred (EntityAlreadyExists) extra detail.",
+            aws.AlreadyExistsAWSError,
+            "EntityAlreadyExists",
+        ),
+        (
+            "aws: [ERROR]: An error occurred (NoSuchEntity) extra detail.",
+            aws.DoesNotExistAWSError,
+            "NoSuchEntity",
+        ),
+    ],
+)
+def test_aws_error_get(message, expected_cls, expected_error_type):
+    """Test AWSError.get factory with various message formats."""
+    err = aws.AWSError.get(message)
+    assert type(err) is expected_cls
+    assert err.error_type == expected_error_type
+    assert str(err) == message

--- a/tox.ini
+++ b/tox.ini
@@ -29,13 +29,13 @@ deps =
     git+https://github.com/juju-solutions/charms.unit_test/#egg=charms.unit_test
     python-openstackclient
     -r src/wheelhouse.txt
-commands = 
+commands =
     pytest --tb native -s -vv \
        --cov-report term-missing --cov=src \
        {posargs} {toxinidir}/tests/unit
 
 [testenv:lint]
-deps = 
+deps =
     flake8
     black
 commands =
@@ -44,7 +44,7 @@ commands =
 
 [testenv:format]
 deps = black
-commands = 
+commands =
     black {toxinidir}/src {toxinidir}/tests
 
 [testenv:integration]
@@ -59,6 +59,5 @@ commands = pytest --tb native --show-capture=no --log-cli-level=INFO -s {posargs
 [testenv:validate-wheelhouse]
 deps =
     git+https://github.com/juju/charm-tools.git
-    path<17
 allowlist_externals = {toxinidir}/tests/validate-wheelhouse.sh
 commands = {toxinidir}/tests/validate-wheelhouse.sh


### PR DESCRIPTION
Partially Resolves issue:
[LP#2143884](https://bugs.launchpad.net/charm-aws-integrator/+bug/2143884)


This pull request primarily improves error handling in the AWS integration layer by updating the error code extraction logic and adding comprehensive unit tests for the error factory method. It also includes minor code cleanups in both the library and tests.

**Error handling improvements:**

* Changed the error code extraction in `AWSError.get` from `re.match` to `re.search`, allowing error codes to be detected anywhere in the message string, not just at the start. This makes error classification more robust, especially for AWS CLI messages that may have prefixes.

**Testing enhancements:**

* Added a parameterized test `test_aws_error_get` in `test_layer_aws.py` to cover various message formats and error types, ensuring that the error factory method correctly identifies and classifies AWS errors under different scenarios.

**Code cleanup:**

* Removed unnecessary blank lines in `aws.py`, `conftest.py`, and `test_aws_integrator.py` for improved code style and consistency. [[1]](diffhunk://#diff-27fb8e0199c0b928742bc6d07805ea17486c365791ab782e14b318e2c14cfc9cL26) [[2]](diffhunk://#diff-0cae8a7ee2d37098b1ad84b543d17cfc1e8535eed5fd6abac88c668bfe354cbbL3) [[3]](diffhunk://#diff-0659818763eaa322c91ea109abeb4a789936b6ebbae29c5f0ea52abfa967b1fcL14)

** Example failure **

```
2026-03-16 09:46:44 ERROR unit.aws-integrator/0.juju-log server.go:405 Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-aws-integrator-0/charm/lib/charms/layer/aws.py", line 629, in _aws
    output = subprocess.check_output(cmd, stderr=subprocess.PIPE)
  File "/usr/lib/python3.10/subprocess.py", line 421, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['aws', '--profile', 'juju', '--output', 'json', 'iam', 'create-role', '--role-name', 'charm.aws.b8b51064-c21e-4316-87cd-af06890e4ad9.kuberne...l-plane', '--assume-role-policy-document', 'file:///var/lib/juju/agents/unit-aws-integrator-0/charm/files/role.json']' returned non-zero exit status 254.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-aws-integrator-0/charm/reactive/aws.py", line 91, in handle_requests
    layer.aws.enable_autoscaling_readonly(
  File "/var/lib/juju/agents/unit-aws-integrator-0/charm/lib/charms/layer/aws.py", line 212, in _enable_policy
    role_name = _get_role_name(application_name, instance_id, region)
  File "/var/lib/juju/agents/unit-aws-integrator-0/charm/lib/charms/layer/aws.py", line 933, in _get_role_name
    _ensure_role(application_name, role_name)
  File "/var/lib/juju/agents/unit-aws-integrator-0/charm/lib/charms/layer/aws.py", line 945, in _ensure_role
    _aws(
  File "/var/lib/juju/agents/unit-aws-integrator-0/charm/lib/charms/layer/aws.py", line 635, in _aws
    raise ae from e
charms.layer.aws.AWSError: aws: [ERROR]: An error occurred (EntityAlreadyExists) when calling the CreateRole operation: Role with name charm.aws.b8b51064-c21e-4316-87cd-af06890e4ad9.kuberne...l-plane already exists.
```